### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,122 @@
+name: 🐛 Bug Report
+description: File an issue about a bug.
+title: "[BUG] "
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please do your best to make the issue as easy to act on as possible, and only submit here if there is clearly a problem with baichuan-7B (ask in [Discussions](https://github.com/baichuan-inc/baichuan-7B/discussions) first if unsure).
+
+  - type: checkboxes
+    id: steps
+    attributes:
+      label: Required prerequisites
+      description: Make sure you've completed the following steps before submitting your issue -- thank you!
+      options:
+        - label: I have read the documentation <https://github.com/baichuan-inc/baichuan-7B/blob/HEAD/README.md>.
+          required: true
+        - label: I have searched the [Issue Tracker](https://github.com/baichuan-inc/baichuan-7B/issues) and [Discussions](https://github.com/baichuan-inc/baichuan-7B/discussions) that this hasn't already been reported. (+1 or comment there if it has.)
+          required: true
+        - label: Consider asking first in a [Discussion](https://github.com/baichuan-inc/baichuan-7B/discussions/new).
+          required: false
+
+  - type: textarea
+    id: system-info
+    attributes:
+      label: System information
+      description: |
+        Describe the characteristic of your environment:
+
+        - Describe how the library was installed (pip, conda, source, ...)
+        - Python version
+        - Versions of any other relevant libraries
+
+        ```python
+        import sys, transformers
+        print(sys.version, sys.platform)
+        print(transformers.__version__)
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Problem description
+      description: >-
+        Provide a short description, state the expected behavior and what actually happens. Include
+        relevant information like what system you are on, and any useful commands / output.
+    validations:
+      required: true
+
+  - type: textarea
+    id: code
+    attributes:
+      label: Reproducible example code
+      description: >-
+        The code should be minimal, have minimal external dependencies, and isolate the functions
+        that cause breakage. Submit matched and complete snippets that can be easily run to diagnose
+        the issue.
+      value: |
+        The Python snippets:
+
+        ```python
+
+        ```
+
+        Command lines:
+
+        ```bash
+
+        ```
+
+        Extra dependencies:
+
+        ```text
+
+        ```
+
+        Steps to reproduce:
+
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: traceback
+    attributes:
+      label: Traceback
+      description: Put the Python traceback information here.
+      placeholder: |
+        Traceback (most recent call last):
+          File ...
+      render: pytb
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: Provide a clear and concise description of what you expected to happen.
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: >-
+        Add any other context about the problem here. Screenshots may also be helpful.
+
+        If you know or suspect the reason for this bug, paste the code lines and suggest modifications.
+
+  - type: checkboxes
+    id: post-steps
+    attributes:
+      label: Checklist
+      description: Make sure you've completed the following steps before submitting your issue -- thank you!
+      options:
+        - label: I have provided all relevant and necessary information above.
+          required: true
+        - label: I have chosen a suitable title for this issue.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Start a discussion
+    url: https://github.com/baichuan-inc/baichuan-7B/discussions/new
+    about: Please ask and answer questions here if unsure.

--- a/.github/ISSUE_TEMPLATE/questions.yml
+++ b/.github/ISSUE_TEMPLATE/questions.yml
@@ -1,0 +1,36 @@
+name: 🤔 Questions / Help / Support
+description: Do you need support?
+title: "[Question] "
+labels: [question]
+body:
+  - type: checkboxes
+    id: steps
+    attributes:
+      label: Required prerequisites
+      description: Make sure you've completed the following steps before submitting your issue -- thank you!
+      options:
+        - label: I have read the documentation <https://github.com/baichuan-inc/baichuan-7B/blob/HEAD/README.md>.
+          required: true
+        - label: I have searched the [Issue Tracker](https://github.com/baichuan-inc/baichuan-7B/issues) and [Discussions](https://github.com/baichuan-inc/baichuan-7B/discussions) that this hasn't already been reported. (+1 or comment there if it has.)
+          required: true
+        - label: Consider asking first in a [Discussion](https://github.com/baichuan-inc/baichuan-7B/discussions/new).
+          required: false
+
+  - type: textarea
+    id: questions
+    attributes:
+      label: Questions
+      description: Describe your questions with relevant resources such as snippets, links, images, etc.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: post-steps
+    attributes:
+      label: Checklist
+      description: Make sure you've completed the following steps before submitting your issue -- thank you!
+      options:
+        - label: I have provided all relevant and necessary information above.
+          required: true
+        - label: I have chosen a suitable title for this issue.
+          required: true


### PR DESCRIPTION
This PR introduces a set of issue templates to enhance and standardize the way issues are created and managed in our GitHub repository. Issue templates serve as a structured guide for creating new issues, providing clear instructions and predefined sections for gathering essential information.