### PR TITLE
Add OpenCompass badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 <div align="center">
 
 [![license](https://img.shields.io/github/license/modelscope/modelscope.svg)](https://github.com/baichuan-inc/Baichuan-7B/blob/main/LICENSE)
+[![evaluation](https://img.shields.io/badge/OpenCompass-Support-royalblue.svg)](https://github.com/internLM/OpenCompass/)
+
 <h4 align="center">
     <p>
         <b>中文</b> |

--- a/README_EN.md
+++ b/README_EN.md
@@ -11,8 +11,13 @@
 🤗 <a href="https://huggingface.co/baichuan-inc/Baichuan-7B" target="_blank">Hugging Face</a> • 🤖 <a href="https://modelscope.cn/organization/baichuan-inc" target="_blank">ModelScope</a> • 💬 <a href="https://github.com/baichuan-inc/Baichuan-7B/blob/main/media/wechat.jpeg?raw=true" target="_blank">WeChat</a>
 </p>
 
+<div align="center">
+  
 [![license](https://img.shields.io/github/license/modelscope/modelscope.svg)](https://github.com/baichuan-inc/Baichuan-7B/blob/main/LICENSE)
 [![evaluation](https://img.shields.io/badge/OpenCompass-Support-royalblue.svg)](https://github.com/internLM/OpenCompass/)
+
+</div>
+
 <h4 align="center">
     <p>
         <b>English</b> |

--- a/README_EN.md
+++ b/README_EN.md
@@ -12,6 +12,7 @@
 </p>
 
 [![license](https://img.shields.io/github/license/modelscope/modelscope.svg)](https://github.com/baichuan-inc/Baichuan-7B/blob/main/LICENSE)
+[![evaluation](https://img.shields.io/badge/OpenCompass-Support-royalblue.svg)](https://github.com/internLM/OpenCompass/)
 <h4 align="center">
     <p>
         <b>English</b> |


### PR DESCRIPTION
Hi team,

Thanks for using OpenCompass! We're thrilled to see more LLM teams adopting the toolkit to evaluate models systematically. We deeply appreciate your dedication to transparency and reproducibility in LLM evaluation. Here we are wondering if you would add a badge to readme, with which visitors can quickly identify and appreciate the rigorous evaluation standards your model has undergone.

BTW, as OpenCompass continues to evolve, we welcome any evaluation requests or ideas for future collaborations. Feel free to let us know if your team needs any assistance.